### PR TITLE
set encoding as nn.Parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PyTest(TestCommand):
 
 setup(
     name='torcharc',
-    version='1.1.1',
+    version='1.1.2',
     description='Build PyTorch networks by specifying architectures.',
     long_description='https://github.com/kengz/torcharc',
     keywords='torcharc',

--- a/torcharc/module/perceiver_io/preprocessor.py
+++ b/torcharc/module/perceiver_io/preprocessor.py
@@ -95,7 +95,7 @@ class FourierPreprocessor(nn.Module):
         spatial_encoding = torch.cat(encodings, dim=-1)  # shape (x, y,... d*(2*num_freq_bands+1))
         # flatten spatial dimensions into 1D
         pos_encoding = rearrange(spatial_encoding, '... c -> (...) c')
-        return pos_encoding
+        return nn.Parameter(pos_encoding)
 
     def get_pos_encoding_dim(self) -> int:
         return len(self.spatial_shape) * (2 * self.num_freq_bands + int(self.cat_pos))


### PR DESCRIPTION
fix(perceiver): set encoding as nn.Parameter

This is so that the encoding can be transferred automatically to the correct device as the model using it.