### PR TITLE
set multi-pos_encodings as ParameterDict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PyTest(TestCommand):
 
 setup(
     name='torcharc',
-    version='1.1.2',
+    version='1.1.3',
     description='Build PyTorch networks by specifying architectures.',
     long_description='https://github.com/kengz/torcharc',
     keywords='torcharc',

--- a/torcharc/module/perceiver_io/preprocessor.py
+++ b/torcharc/module/perceiver_io/preprocessor.py
@@ -129,10 +129,10 @@ class MultimodalPreprocessor(nn.Module):
         total_seq_len = ps.sum_by(self.out_shapes, ps.head)
         max_channels = ps.max_by(self.out_shapes, ps.last)[-1]
         common_channels = max_channels + pad_channels
-        self.pos_encodings = {
+        self.pos_encodings = nn.ParameterDict({
             mode: build_learned_pos_encoding(1, common_channels - out_shape[-1])
             for mode, out_shape in self.out_shapes.items()
-        }
+        })
         self.out_shape = [total_seq_len, common_channels]
 
     def pos_encoding_pad(self, mode: str, out: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
fix(perceiver): set multi-pos_encodings as ParameterDict
- this is to allow proper device transfer of pos_encodings